### PR TITLE
pear2/net_transmitter were not downloading due to version name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "pear2/net_transmitter": ">=1.0.0a5"
+        "pear2/net_transmitter": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable",


### PR DESCRIPTION
with **pear2/net_transmitter** 1.0.0a5 version. Composer can't install the package it's showing the following error:
` pear2/net_routeros dev-master requires pear2/net_transmitter >=1.0.0a5 -> no matching package found.`

So I just changed the required version to install this library with composer.