### PR TITLE
Update ResponseCollection.php

### DIFF
--- a/src/PEAR2/Net/RouterOS/ResponseCollection.php
+++ b/src/PEAR2/Net/RouterOS/ResponseCollection.php
@@ -284,7 +284,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      */
     public function __debugInfo()
     {
-        return $this->toArray(self::ARRAY_INDEXED | self::ARRAY_RECURSIVE);
+        return $this->toArray(self::ARRAY_RECURSIVE);
     }
 
     /**


### PR DESCRIPTION
This change fix issue when want var_dump or print_r response object.

$responses = $client->sendSync(new RouterOS\Request('/system  resource print'));
var_dump($responses);

PHP Notice:  Undefined index:  in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 258
PHP Warning:  asort() expects parameter 1 to be array, null given in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 259
PHP Warning:  array_flip() expects parameter 1 to be array, null given in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 260
PHP Warning:  array_intersect_key(): Argument #2 is not an array in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 263
PHP Warning:  array_combine() expects parameter 1 to be array, null given in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 263
PHP Warning:  Invalid argument supplied for foreach() in /root/vendor/pear2/net_routeros/src/PEAR2/Net/RouterOS/ResponseCollection.php on line 267
object(PEAR2\Net\RouterOS\ResponseCollection)#11 (0) {
}

