### PR TITLE
Fix: class Util method find() was returning just concatenated string …

### DIFF
--- a/src/PEAR2/Net/RouterOS/Util.php
+++ b/src/PEAR2/Net/RouterOS/Util.php
@@ -457,8 +457,8 @@ class Util implements Countable
                     $idList .= strtolower(
                         is_string($newId)
                         ? $newId
-                        : stream_get_contents($newId) . ','
-                    );
+                        : stream_get_contents($newId)
+                    ) . ',';
                 }
             } elseif (is_callable($criteria)) {
                 $idCache = array();


### PR DESCRIPTION
…instead of comma-separated

