### PR TITLE
Resolve deprecation notices in modern PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "wiki": "https://github.com/pear2/Net_RouterOS/wiki"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.4",
         "pear2/net_transmitter": ">=1.0.0b1 || dev-develop@dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "wiki": "https://github.com/pear2/Net_RouterOS/wiki"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=5.3",
         "pear2/net_transmitter": ">=1.0.0b1 || dev-develop@dev"
     },
     "require-dev": {

--- a/src/PEAR2/Net/RouterOS/Message.php
+++ b/src/PEAR2/Net/RouterOS/Message.php
@@ -34,7 +34,6 @@ use IteratorAggregate;
  * Required for IteratorAggregate::getIterator() to work properly with foreach.
  */
 use ArrayObject;
-use Traversable;
 
 /**
  * Represents a RouterOS message.
@@ -181,7 +180,8 @@ abstract class Message implements IteratorAggregate, Countable
      * @see getArgument()
      * @see setArgument()
      */
-    public function getIterator(): Traversable
+    #[\ReturnTypeWillChange]
+    public function getIterator()
     {
         return new ArrayObject($this->attributes);
     }
@@ -191,7 +191,8 @@ abstract class Message implements IteratorAggregate, Countable
      *
      * @return int The number of attributes.
      */
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return count($this->attributes);
     }

--- a/src/PEAR2/Net/RouterOS/Message.php
+++ b/src/PEAR2/Net/RouterOS/Message.php
@@ -34,6 +34,7 @@ use IteratorAggregate;
  * Required for IteratorAggregate::getIterator() to work properly with foreach.
  */
 use ArrayObject;
+use Traversable;
 
 /**
  * Represents a RouterOS message.
@@ -180,7 +181,7 @@ abstract class Message implements IteratorAggregate, Countable
      * @see getArgument()
      * @see setArgument()
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayObject($this->attributes);
     }
@@ -190,7 +191,7 @@ abstract class Message implements IteratorAggregate, Countable
      *
      * @return int The number of attributes.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->attributes);
     }

--- a/src/PEAR2/Net/RouterOS/Response.php
+++ b/src/PEAR2/Net/RouterOS/Response.php
@@ -225,7 +225,7 @@ class Response extends Message
                     $word = $com->getNextWordAsStream();
                     $ind = fread($word, 1);
                     if ('=' === $ind || '.' === $ind) {
-                        $prefix = stream_get_line($word, null, '=');
+                        $prefix = stream_get_line($word, 0, '=');
                     }
                     if ('=' === $ind) {
                         $value = fopen('php://temp', 'r+b');

--- a/src/PEAR2/Net/RouterOS/ResponseCollection.php
+++ b/src/PEAR2/Net/RouterOS/ResponseCollection.php
@@ -294,7 +294,8 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return int The number of responses in the collection.
      */
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return count($this->responses);
     }
@@ -308,7 +309,8 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return bool TRUE if the offset exists, FALSE otherwise.
      */
-    public function offsetExists($offset): bool
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
     {
         return is_int($offset)
             ? array_key_exists($offset, $this->responses)
@@ -468,7 +470,8 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return bool TRUE if the pointer is valid, FALSE otherwise.
      */
-    public function valid(): bool
+    #[\ReturnTypeWillChange]
+    public function valid()
     {
         return $this->offsetExists($this->position);
     }

--- a/src/PEAR2/Net/RouterOS/ResponseCollection.php
+++ b/src/PEAR2/Net/RouterOS/ResponseCollection.php
@@ -294,7 +294,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return int The number of responses in the collection.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->responses);
     }
@@ -308,7 +308,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return bool TRUE if the offset exists, FALSE otherwise.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return is_int($offset)
             ? array_key_exists($offset, $this->responses)
@@ -379,21 +379,21 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
     /**
      * Moves the position pointer to a specified position.
      *
-     * @param int|string $position The position to move to. If the collection is
+     * @param int|string $offset The position to move to. If the collection is
      *     indexed, you can also supply a value to move the pointer to.
      *     A non-existent index will move the pointer to "-1".
      *
      * @return Response|false The {@link Response} at the specified position,
      *     or FALSE if the specified position is not valid.
      */
-    public function seek($position)
+    public function seek($offset)
     {
-        $this->position = is_int($position)
-            ? ($position >= 0
-            ? $position
-            : count($this->responses) + $position)
-            : ($this->offsetExists($position)
-            ? $this->responsesIndex[$this->index][$position]
+        $this->position = is_int($offset)
+            ? ($offset >= 0
+            ? $offset
+            : count($this->responses) + $offset)
+            : ($this->offsetExists($offset)
+            ? $this->responsesIndex[$this->index][$offset]
             : -1);
         return $this->current();
     }
@@ -404,6 +404,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      * @return Response|false The next {@link Response} object,
      *     or FALSE if the position is not valid.
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
@@ -416,6 +417,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      * @return Response|false The response at the current pointer position,
      *     or FALSE if the position is not valid.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->valid() ? $this->responses[$this->position] : false;
@@ -427,6 +429,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      * @return Response|false The next {@link Response} object,
      *     or FALSE if the position is not valid.
      */
+    #[\ReturnTypeWillChange]
     public function prev()
     {
         --$this->position;
@@ -440,6 +443,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      * @return Response|false The last response in the collection,
      *     or FALSE if the collection is empty.
      */
+    #[\ReturnTypeWillChange]
     public function end()
     {
         $this->position = count($this->responses) - 1;
@@ -453,6 +457,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *     i.e. the pointer position itself, or FALSE if the position
      *     is not valid.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->valid() ? $this->position : false;
@@ -463,7 +468,7 @@ class ResponseCollection implements ArrayAccess, SeekableIterator, Countable
      *
      * @return bool TRUE if the pointer is valid, FALSE otherwise.
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->offsetExists($this->position);
     }

--- a/src/PEAR2/Net/RouterOS/Util.php
+++ b/src/PEAR2/Net/RouterOS/Util.php
@@ -952,7 +952,7 @@ EOT
      * @return int The number of items, or -1 on failure (e.g. if the
      *     current menu does not have a "print" command or items to be counted).
      */
-    public function count(Query $query = null, $from = null)
+    public function count(Query $query = null, $from = null): int
     {
         $countRequest = new Request(
             $this->menu . '/print count-only=""',

--- a/src/PEAR2/Net/RouterOS/Util.php
+++ b/src/PEAR2/Net/RouterOS/Util.php
@@ -952,7 +952,8 @@ EOT
      * @return int The number of items, or -1 on failure (e.g. if the
      *     current menu does not have a "print" command or items to be counted).
      */
-    public function count(Query $query = null, $from = null): int
+    #[\ReturnTypeWillChange]
+    public function count(Query $query = null, $from = null)
     {
         $countRequest = new Request(
             $this->menu . '/print count-only=""',


### PR DESCRIPTION
Gets rid of these notices:
```
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\Message::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/Message.php on line 183
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\Message::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/Message.php on line 193
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\Util::count(?PEAR2\Net\RouterOS\Query $query = null, $from = null) should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/Util.php on line 955
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 311
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 326
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 348
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 364
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::seek($position) should either be compatible with SeekableIterator::seek(int $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 389
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 419
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 407
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 456
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 466
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 374
PHP Deprecated:  Return type of PEAR2\Net\RouterOS\ResponseCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/PEAR2/Net/RouterOS/ResponseCollection.php on line 297
PHP Deprecated:  stream_get_line(): Passing null to parameter #2 ($length) of type int is deprecated in src/PEAR2/Net/RouterOS/Response.php on line 228
```
Used the `#[\ReturnTypeWillChange]` attribute in a few places since `mixed` is not available as a return type in the (technically) still supported PHP 7.4.