### PR TITLE
Allow empty response from RouterOS version >= 7.18

### DIFF
--- a/src/PEAR2/Net/RouterOS/Response.php
+++ b/src/PEAR2/Net/RouterOS/Response.php
@@ -53,6 +53,11 @@ class Response extends Message
     const TYPE_DATA = '!re';
 
     /**
+     * A response with empty data (from RouterOS 7.18).
+     */
+    const TYPE_EMPTY = '!empty';
+
+    /**
      * A response signifying error.
      */
     const TYPE_ERROR = '!trap';
@@ -270,6 +275,7 @@ class Response extends Message
         switch ($type) {
         case self::TYPE_FINAL:
         case self::TYPE_DATA:
+        case self::TYPE_EMPTY:
         case self::TYPE_ERROR:
         case self::TYPE_FATAL:
             $this->_type = $type;


### PR DESCRIPTION
In RouterOS 7.18, response with empty data has !empty sentence:
*) console - put !empty sentence when API query returns nothing;

Se more: https://mikrotik.com/download/changelogs#c-stable-v7_18